### PR TITLE
新增roformer-sim转化与集成roberta-small/tiny

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # bert4torch
+
 **一款用pytorch来复现bert4keras的简洁训练框架**
 
-[![licence](https://img.shields.io/github/license/Tongjilibo/bert4torch.svg?maxAge=3600)](https://github.com/Tongjilibo/bert4torch/blob/master/LICENSE) 
-[![GitHub release](https://img.shields.io/github/release/Tongjilibo/bert4torch.svg?maxAge=3600)](https://github.com/Tongjilibo/bert4torch/releases) 
-[![PyPI](https://img.shields.io/pypi/v/bert4torch?label=pypi%20package)](https://pypi.org/project/bert4torch/) 
+[![licence](https://img.shields.io/github/license/Tongjilibo/bert4torch.svg?maxAge=3600)](https://github.com/Tongjilibo/bert4torch/blob/master/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/Tongjilibo/bert4torch.svg?maxAge=3600)](https://github.com/Tongjilibo/bert4torch/releases)
+[![PyPI](https://img.shields.io/pypi/v/bert4torch?label=pypi%20package)](https://pypi.org/project/bert4torch/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/bert4torch)](https://pypistats.org/packages/bert4torch)
 [![GitHub stars](https://img.shields.io/github/stars/Tongjilibo/bert4torch?style=social)](https://github.com/Tongjilibo/bert4torch)
 [![GitHub Issues](https://img.shields.io/github/issues/Tongjilibo/bert4torch.svg)](https://github.com/Tongjilibo/bert4torch/issues)
@@ -14,20 +15,26 @@
 [Examples](https://github.com/Tongjilibo/bert4torch/blob/master/examples)
 
 ## 1. 下载安装
+
 安装稳定版
+
 ```shell
 pip install bert4torch
 ```
+
 安装最新版
+
 ```shell
 pip install git+https://www.github.com/Tongjilibo/bert4torch.git
 ```
+
 - **注意事项**：pip包的发布慢于git上的开发版本，git clone**注意引用路径**，注意权重是否需要转换
 - **测试用例**：`git clone https://github.com/Tongjilibo/bert4torch`，修改example中的预训练模型文件路径和数据路径即可启动脚本
 - **自行训练**：针对自己的数据，修改相应的数据处理代码块
 - **开发环境**：使用`torch==1.10`版本进行开发，如其他版本遇到不适配，欢迎反馈
 
 ## 2. 功能
+
 - **核心功能**：加载bert、roberta、albert、xlnet、nezha、bart、RoFormer、RoFormer_V2、ELECTRA、GPT、GPT2、T5、GAU-alpha、ERNIE等预训练权重继续进行finetune、并支持在bert基础上灵活定义自己模型
 - [**丰富示例**](https://github.com/Tongjilibo/bert4torch/blob/master/examples/)：包含[pretrain](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain)、[sentence_classfication](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_classfication)、[sentence_embedding](https://github.com/Tongjilibo/bert4torch/tree/master/examples/sentence_embedding)、[sequence_labeling](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sequence_labeling)、[relation_extraction](https://github.com/Tongjilibo/bert4torch/blob/master/examples/relation_extraction)、[seq2seq](https://github.com/Tongjilibo/bert4torch/blob/master/examples/seq2seq)、[serving](https://github.com/Tongjilibo/bert4torch/blob/master/examples/serving/)等多种解决方案
 - **实验验证**：已在公开数据集实验验证，使用如下[examples数据集](https://github.com/Tongjilibo/bert4torch/blob/master/examples/README.md)
@@ -35,43 +42,46 @@ pip install git+https://www.github.com/Tongjilibo/bert4torch.git
 - **其他特性**：[加载transformers库模型](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/tutorials_load_transformers_model.py)一起使用；调用方式简洁高效；有训练进度条动态展示；配合torchinfo打印参数量；默认Logger和Tensorboard简便记录训练过程；自定义fit过程，满足高阶需求
 - **训练过程**：
 
-    ```text
-    2022-10-28 23:16:10 - Start Training
-    2022-10-28 23:16:10 - Epoch: 1/5
-    5000/5000 [==============================] - 13s 3ms/step - loss: 0.1351 - acc: 0.9601
-    Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 798.09it/s] 
-    test_acc: 0.98045. best_test_acc: 0.98045
+  ```text
+  2022-10-28 23:16:10 - Start Training
+  2022-10-28 23:16:10 - Epoch: 1/5
+  5000/5000 [==============================] - 13s 3ms/step - loss: 0.1351 - acc: 0.9601
+  Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 798.09it/s] 
+  test_acc: 0.98045. best_test_acc: 0.98045
 
-    2022-10-28 23:16:27 - Epoch: 2/5
-    5000/5000 [==============================] - 13s 3ms/step - loss: 0.0465 - acc: 0.9862
-    Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 635.78it/s] 
-    test_acc: 0.98280. best_test_acc: 0.98280
+  2022-10-28 23:16:27 - Epoch: 2/5
+  5000/5000 [==============================] - 13s 3ms/step - loss: 0.0465 - acc: 0.9862
+  Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 635.78it/s] 
+  test_acc: 0.98280. best_test_acc: 0.98280
 
-    2022-10-28 23:16:44 - Epoch: 3/5
-    5000/5000 [==============================] - 15s 3ms/step - loss: 0.0284 - acc: 0.9915
-    Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 673.60it/s] 
-    test_acc: 0.98365. best_test_acc: 0.98365
+  2022-10-28 23:16:44 - Epoch: 3/5
+  5000/5000 [==============================] - 15s 3ms/step - loss: 0.0284 - acc: 0.9915
+  Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 673.60it/s] 
+  test_acc: 0.98365. best_test_acc: 0.98365
 
-    2022-10-28 23:17:03 - Epoch: 4/5
-    5000/5000 [==============================] - 15s 3ms/step - loss: 0.0179 - acc: 0.9948
-    Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 692.34it/s] 
-    test_acc: 0.98265. best_test_acc: 0.98365
+  2022-10-28 23:17:03 - Epoch: 4/5
+  5000/5000 [==============================] - 15s 3ms/step - loss: 0.0179 - acc: 0.9948
+  Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 692.34it/s] 
+  test_acc: 0.98265. best_test_acc: 0.98365
 
-    2022-10-28 23:17:21 - Epoch: 5/5
-    5000/5000 [==============================] - 14s 3ms/step - loss: 0.0129 - acc: 0.9958
-    Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 701.77it/s] 
-    test_acc: 0.98585. best_test_acc: 0.98585
+  2022-10-28 23:17:21 - Epoch: 5/5
+  5000/5000 [==============================] - 14s 3ms/step - loss: 0.0129 - acc: 0.9958
+  Evaluate: 100%|██████████████████████████████████████████████████| 2500/2500 [00:03<00:00, 701.77it/s] 
+  test_acc: 0.98585. best_test_acc: 0.98585
 
-    2022-10-28 23:17:37 - Finish Training
-    ```
+  2022-10-28 23:17:37 - Finish Training
+  ```
 
 ## 3. 快速上手
+
 - [Quick-Start](https://bert4torch.readthedocs.io/en/latest//Quick-Start.html)
 - [快速上手教程](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/Tutorials.md)，[教程示例](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials)，[实战示例](https://github.com/Tongjilibo/bert4torch/blob/master/examples)
 - [bert4torch介绍(知乎)](https://zhuanlan.zhihu.com/p/486329434)，[bert4torch快速上手(知乎)](https://zhuanlan.zhihu.com/p/508890807)，[bert4torch又双叒叕更新啦(知乎)](https://zhuanlan.zhihu.com/p/560885427?)
 
 ## 4. 版本说明
+
 ### 4.1 更新历史
+
 - **v0.2.7.post2**：20230310 增加lion优化器, 修复albert_unshared加载权重, 修复lm系列(gpt, seq2seq)存在的forward参数不对的问题，修复GlobalPointer使用rope的bug
 - **v0.2.7**：20230213 修复random_sample()的bug，适配v0.0.6的torch4keras：增加resume_from_checkpoint和save_to_checkpoint；增加add_trainer方法，重构了Trainer(BaseModel)的实现，增加了AccelerateCallback
 - **v0.2.6**：20221231 build_transformer_model需显式指定add_trainer才从BaseModel继承, 增加guwenbert, macbert，text2vec-bert-chinese, wobert预训练模型，允许position_ids从padding开始, transformer.configs支持点操作，可以使用torch4keras的Trainer(net)来初始化, 修复tokenizer的切分subtoken的bug, 允许embedding_size!=hidden_size
@@ -90,18 +100,20 @@ pip install git+https://www.github.com/Tongjilibo/bert4torch.git
 - **v0.1.3**：20220409 初始版本
 
 ### 4.2 版本对应关系
-| bert4torch版本 |  torch4keras版本 |
-|  ----  |  ----  |
-|  0.2.7.post2  | 0.0.6 |
-|  0.2.7  | 0.0.6 |
-|  0.2.6  | 0.0.5 |
-|  0.2.5  | 0.0.4 |
-|  0.2.4  | 0.0.3.post2 |
-|  0.2.3  | 0.0.2 |
-|  <0.2.3  | —— |
 
+
+| bert4torch版本 | torch4keras版本 |
+| ---------------- | ----------------- |
+| 0.2.7.post2    | 0.0.6           |
+| 0.2.7          | 0.0.6           |
+| 0.2.6          | 0.0.5           |
+| 0.2.5          | 0.0.4           |
+| 0.2.4          | 0.0.3.post2     |
+| 0.2.3          | 0.0.2           |
+| <0.2.3         | ——            |
 
 ## 5. 更新：
+
 - **20230316**：增加llama-7b预训练模型, 修改rope为不使用max_position, 增加prompt_clue和nezha_gpt_dialog的finetune示例(skykiseki用户)，修复model.half()类型不一致问题
 - **20230310**：增加lion优化器, 修改dp和ddp示例更易用，增加PromptCLUE模型, 修复albert_unshared加载权重, 增加uer-gpt2-chinese预训练模型，修复lm系列(gpt, seq2seq)存在的forward参数不对的问题，修复GlobalPointer使用rope的bug
 - **20230212**：兼容accelerate包, 增加ChatYuan模型，修复random_sample()的bug
@@ -131,49 +143,52 @@ pip install git+https://www.github.com/Tongjilibo/bert4torch.git
 - **20220322**：添加GPT、GPT2、T5模型
 - **20220312**：初版提交
 
-
 ## 6. 预训练权重
+
 - 部分权重是要加载修改的[config.json](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
 
-| 模型分类 |  权重来源 | 权重链接 | 备注(若有) | 
-|  ----  |  ----  | ----  | ----  |
-|  bert  | 谷歌原版bert(即bert-base-chinese) | [tf](https://github.com/google-research/bert)，[torch](https://huggingface.co/bert-base-chinese) | [tf转pytorch命令](https://huggingface.co/docs/transformers/converting_tensorflow_models)，[转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_bert-base-chinese.py)
-|  bert  | 哈工大chinese-bert-wwm-ext | [tf/torch](https://github.com/ymcui/Chinese-BERT-wwm)，[torch](https://huggingface.co/hfl/chinese-bert-wwm-ext) |
-|  macbert  | 哈工大chinese-macbert-base/large | [tf/torch](https://github.com/ymcui/MacBERT)，[torch](https://huggingface.co/hfl/chinese-macbert-base) |
-| robert | 哈工大chinese-robert-wwm-ext | [tf/torch](https://github.com/ymcui/Chinese-BERT-wwm)，[torch](https://huggingface.co/hfl/chinese-roberta-wwm-ext)
-| deberta_v2| IDEA Erlangshen-DeBERTa-v2 | [torch](https://huggingface.co/IDEA-CCNL/Erlangshen-DeBERTa-v2-320M-Chinese/tree/main) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_deberta_v2.py) |
-| guwenbert | 古文bert | [torch](https://huggingface.co/ethanyt/guwenbert-base)|[转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_guwenbert-base.py)|
-| xlnet | 哈工大xlnet | [tf/torch](https://github.com/ymcui/Chinese-XLNet) | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
-| electra | 哈工大electra | [tf](https://github.com/ymcui/Chinese-ELECTRA)，[torch](https://huggingface.co/hfl/chinese-electra-base-discriminator)
-| macbert | 哈工大macbert | [tf](https://github.com/ymcui/MacBERT)，[torch](https://huggingface.co/hfl/chinese-macbert-base)
-| albert | brightmart | [tf](https://github.com/brightmart/albert_zh)，[torch](https://huggingface.co/voidful)，[torch](https://github.com/lonePatient/albert_pytorch)
-| ernie | 百度文心 |[paddle](https://github.com/PaddlePaddle/ERNIE)，[torch](https://huggingface.co/nghuyong) | 
-| roformer | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/roformer)，[torch](https://huggingface.co/junnyu/roformer_chinese_base) |  
-| roformer_v2 | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/roformer-v2)，[torch](https://huggingface.co/junnyu/roformer_v2_chinese_char_base) | 
-| simbert | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/simbert)，[torch_base](https://huggingface.co/peterchou/simbert-chinese-base/tree/main) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_simbert.py) |
-| simbert_v2/roformer-sim | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/roformer-sim)，[torch](https://huggingface.co/junnyu/roformer_chinese_sim_char_base) | 
-| gau-alpha | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/GAU-alpha) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_GAU_alpha.py)
-| wobert | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/WoBERT)，[torch_base](https://huggingface.co/junnyu/wobert_chinese_base)，[torch_plus_base](https://huggingface.co/junnyu/wobert_chinese_plus_base)||
-| nezha | 华为 | [tf](https://github.com/huawei-noah/Pretrained-Language-Model/tree/master/NEZHA-TensorFlow)，[torch](https://github.com/lonePatient/NeZha_Chinese_PyTorch) | 
-| gpt | thu-coai/CDial-GPT | [torch](https://github.com/thu-coai/CDial-GPT) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt__CDial-GPT-LCCC.py)
-| gpt2 | 清华26亿 cmp_lm | [torch](https://github.com/TsinghuaAI/CPM-1-Generate) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__cmp_lm_2.6b.py)
-| gpt2 | 中文GPT2_ML模型 | [tf](https://github.com/imcaspar/gpt2-ml)，[torch](https://github.com/ghosthamlet/gpt2-ml-torch) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__gpt2-ml.py)
-| gpt2 | UER | [torch](https://huggingface.co/uer/gpt2-chinese-cluecorpussmall) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__uer-gpt2-chinese.py) |
-| t5 | UER | [torch](https://huggingface.co/uer/t5-base-chinese-cluecorpussmall) | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
-| mt5 | 谷歌 | [torch](https://huggingface.co/google/mt5-base) | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
-| t5_pegasus | 追一科技 | [tf](https://github.com/ZhuiyiTechnology/t5-pegasus) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_t5_pegasus.py)
-| bart | 复旦 | [torch](https://github.com/fastnlp/CPT) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_bart_fudanNLP.py)
-| text2vec | text2vec-base-chinese | [torch](https://huggingface.co/shibing624/text2vec-base-chinese) | 
-| chatyuan | clue-ai | [torch](https://github.com/clue-ai/ChatYuan) | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
-| PromptCLUE | clue-ai | [torch](https://github.com/clue-ai/PromptCLUE) | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)
-| llama | facebook | [torch](https://github.com/facebookresearch/llama) | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_llama_facebook.py)
+
+| 模型分类                | 权重来源                          | 权重链接                                                                                                                                                                                     | 备注(若有)                                                                                                                                                                                                      |
+| ------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bert                    | 谷歌原版bert(即bert-base-chinese) | [tf](https://github.com/google-research/bert)，[torch](https://huggingface.co/bert-base-chinese)                                                                                             | [tf转pytorch命令](https://huggingface.co/docs/transformers/converting_tensorflow_models)，[转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_bert-base-chinese.py) |
+| bert                    | 哈工大chinese-bert-wwm-ext        | [tf/torch](https://github.com/ymcui/Chinese-BERT-wwm)，[torch](https://huggingface.co/hfl/chinese-bert-wwm-ext)                                                                              |                                                                                                                                                                                                                 |
+| macbert                 | 哈工大chinese-macbert-base/large  | [tf/torch](https://github.com/ymcui/MacBERT)，[torch](https://huggingface.co/hfl/chinese-macbert-base)                                                                                       |                                                                                                                                                                                                                 |
+| roberta                 | 哈工大chinese-roberta-wwm-ext     | [tf/torch](https://github.com/ymcui/Chinese-BERT-wwm)，[torch](https://huggingface.co/hfl/chinese-roberta-wwm-ext)                                                                           |                                                                                                                                                                                                                 |
+| roberta-small/tiny      | 追一科技, UER                     | [tf](https://github.com/ZhuiyiTechnology/pretrained-models), [torch](https://huggingface.co/uer/roberta-tiny-word-chinese-cluecorpussmall)                                                   | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_roberta-small.py)                                                                                               |
+| deberta_v2              | IDEA Erlangshen-DeBERTa-v2        | [torch](https://huggingface.co/IDEA-CCNL/Erlangshen-DeBERTa-v2-320M-Chinese/tree/main)                                                                                                       | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_deberta_v2.py)                                                                                                  |
+| guwenbert               | 古文bert                          | [torch](https://huggingface.co/ethanyt/guwenbert-base)                                                                                                                                       | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_guwenbert-base.py)                                                                                              |
+| xlnet                   | 哈工大xlnet                       | [tf/torch](https://github.com/ymcui/Chinese-XLNet)                                                                                                                                           | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)                                                                                                            |
+| electra                 | 哈工大electra                     | [tf](https://github.com/ymcui/Chinese-ELECTRA)，[torch](https://huggingface.co/hfl/chinese-electra-base-discriminator)                                                                       |                                                                                                                                                                                                                 |
+| macbert                 | 哈工大macbert                     | [tf](https://github.com/ymcui/MacBERT)，[torch](https://huggingface.co/hfl/chinese-macbert-base)                                                                                             |                                                                                                                                                                                                                 |
+| albert                  | brightmart                        | [tf](https://github.com/brightmart/albert_zh)，[torch](https://huggingface.co/voidful)，[torch](https://github.com/lonePatient/albert_pytorch)                                               |                                                                                                                                                                                                                 |
+| ernie                   | 百度文心                          | [paddle](https://github.com/PaddlePaddle/ERNIE)，[torch](https://huggingface.co/nghuyong)                                                                                                    |                                                                                                                                                                                                                 |
+| roformer                | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/roformer)，[torch](https://huggingface.co/junnyu/roformer_chinese_base)                                                                             |                                                                                                                                                                                                                 |
+| roformer_v2             | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/roformer-v2)，[torch](https://huggingface.co/junnyu/roformer_v2_chinese_char_base)                                                                  |                                                                                                                                                                                                                 |
+| simbert                 | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/simbert)，[torch_base](https://huggingface.co/peterchou/simbert-chinese-base/tree/main)                                                             | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_simbert.py)                                                                                                     |
+| simbert_v2/roformer-sim | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/roformer-sim)，[torch](https://huggingface.co/junnyu/roformer_chinese_sim_char_base)                                                                | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_roformer-sim.py)                                                                                                |
+| gau-alpha               | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/GAU-alpha)                                                                                                                                          | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_GAU_alpha.py)                                                                                                   |
+| wobert                  | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/WoBERT)，[torch_base](https://huggingface.co/junnyu/wobert_chinese_base)，[torch_plus_base](https://huggingface.co/junnyu/wobert_chinese_plus_base) |                                                                                                                                                                                                                 |
+| nezha                   | 华为                              | [tf](https://github.com/huawei-noah/Pretrained-Language-Model/tree/master/NEZHA-TensorFlow)，[torch](https://github.com/lonePatient/NeZha_Chinese_PyTorch)                                   |                                                                                                                                                                                                                 |
+| gpt                     | thu-coai/CDial-GPT                | [torch](https://github.com/thu-coai/CDial-GPT)                                                                                                                                               | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt__CDial-GPT-LCCC.py)                                                                                         |
+| gpt2                    | 清华26亿 cmp_lm                   | [torch](https://github.com/TsinghuaAI/CPM-1-Generate)                                                                                                                                        | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__cmp_lm_2.6b.py)                                                                                           |
+| gpt2                    | 中文GPT2_ML模型                   | [tf](https://github.com/imcaspar/gpt2-ml)，[torch](https://github.com/ghosthamlet/gpt2-ml-torch)                                                                                             | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__gpt2-ml.py)                                                                                               |
+| gpt2                    | UER                               | [torch](https://huggingface.co/uer/gpt2-chinese-cluecorpussmall)                                                                                                                             | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_gpt2__uer-gpt2-chinese.py)                                                                                      |
+| t5                      | UER                               | [torch](https://huggingface.co/uer/t5-base-chinese-cluecorpussmall)                                                                                                                          | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)                                                                                                            |
+| mt5                     | 谷歌                              | [torch](https://huggingface.co/google/mt5-base)                                                                                                                                              | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)                                                                                                            |
+| t5_pegasus              | 追一科技                          | [tf](https://github.com/ZhuiyiTechnology/t5-pegasus)                                                                                                                                         | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_t5_pegasus.py)                                                                                                  |
+| bart                    | 复旦                              | [torch](https://github.com/fastnlp/CPT)                                                                                                                                                      | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_bart_fudanNLP.py)                                                                                               |
+| text2vec                | text2vec-base-chinese             | [torch](https://huggingface.co/shibing624/text2vec-base-chinese)                                                                                                                             |                                                                                                                                                                                                                 |
+| chatyuan                | clue-ai                           | [torch](https://github.com/clue-ai/ChatYuan)                                                                                                                                                 | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)                                                                                                            |
+| PromptCLUE              | clue-ai                           | [torch](https://github.com/clue-ai/PromptCLUE)                                                                                                                                               | [config](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/PLM_config.md)                                                                                                            |
+| llama                   | facebook                          | [torch](https://github.com/facebookresearch/llama)                                                                                                                                           | [转换脚本](https://github.com/Tongjilibo/bert4torch/blob/master/examples/convert_script/convert_llama_facebook.py)                                                                                              |
 
 ## 7. 鸣谢
-- 感谢苏神实现的[bert4keras](https://github.com/bojone/bert4keras)，本实现有不少地方参考了bert4keras的源码，在此衷心感谢大佬的无私奉献; 
+
+- 感谢苏神实现的[bert4keras](https://github.com/bojone/bert4keras)，本实现有不少地方参考了bert4keras的源码，在此衷心感谢大佬的无私奉献;
 - 其次感谢项目[bert4pytorch](https://github.com/MuQiuJun-AI/bert4pytorch)，也是在该项目的指引下给了我用pytorch来复现bert4keras的想法和思路。
 
-
 ## 8. 引用
+
 ```
 @misc{bert4torch,
   title={bert4torch},
@@ -184,20 +199,12 @@ pip install git+https://www.github.com/Tongjilibo/bert4torch.git
 ```
 
 ## 9. 交流
+
 - Wechat Discussions
 
 <table border="0">
   <tbody>
     <tr align="center" >
       <td>
-        ​ <a href="https://github.com/Tongjilibo"><img width="200" height="250" src="./docs/pics/wechat.jpg" alt="pic"></a><br>
-        ​ <a href="https://github.com/Tongjilibo">微信号</a> ​
-​
-      </td>
-      <td>
-         <a href="https://github.com/Tongjilibo"><img width="200" height="250" src="./docs/pics/wechat_group.jpg" alt="pic"></a><br>
-         <a href="https://github.com/Tongjilibo">微信群</a> ​
-      </td>
-    </tr>
-  </tbody>
-</table>
+         <a href="https://github.com/Tongjilibo"><img width="200" height="250" src="./docs/pics/wechat.jpg" alt="pic"></a><br>
+         <a href="https://github.com/Tongjilibo">微信号</a>

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@
 - [basic_language_model_nezha_gen_gpt.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_nezha_gen_gpt.py)：测试[GPTBase（又叫NEZHE-GEN）](https://github.com/huawei-noah/Pretrained-Language-Model/tree/master/NEZHA-Gen-TensorFlow)的生成效果。
 - [basic_make_uncased_model_cased.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_make_uncased_model_cased.py)：通过简单修改词表，使得不区分大小写的模型有区分大小写的能力。
 - [basic_language_model_bert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_bert.py)：测试BERT的MLM模型效果。
-- [basic_language_model_roberta_small.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_small.py)：测试Roberta的MLM模型效果。
+- [basic_language_model_roberta_small.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_small.py)：测试Roberta-small的MLM模型效果。
 - [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
 - [basic_language_model_ernie.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_ernie.py)：测试百度文心ERNIE的MLM模型效果。
 - [basic_language_model_GAU_alpha.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_GAU_alpha.py)：测试[GAU-alpha](https://github.com/ZhuiyiTechnology/GAU-alpha)的MLM模型效果。

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,13 +33,6 @@
 - [basic_language_model_albert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_albert.py): 测试[albert_chinese](https://github.com/brightmart/albert_zh)模型。
 - [basic_language_model_llama.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_llama.py): 测试[llama](https://github.com/facebookresearch/llama)模型。
 
-- [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
--
-
-
-- [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
--
-
 
 ## 文本分类
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 # 一、example简介
+
 ## 基础测试
+
 - [basic_test_tokenizer.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_test_tokenizer.py): 测试tokenizer和transformers包的结果一致。
 - [basic_test_parallel_apply.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_test_parallel_apply.py): 测试parallel_apply的效果。
 - [basic_extract_features.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_extract_features.py)：测试BERT对句子的编码序列。
@@ -7,6 +9,7 @@
 - [basic_language_model_nezha_gen_gpt.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_nezha_gen_gpt.py)：测试[GPTBase（又叫NEZHE-GEN）](https://github.com/huawei-noah/Pretrained-Language-Model/tree/master/NEZHA-Gen-TensorFlow)的生成效果。
 - [basic_make_uncased_model_cased.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_make_uncased_model_cased.py)：通过简单修改词表，使得不区分大小写的模型有区分大小写的能力。
 - [basic_language_model_bert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_bert.py)：测试BERT的MLM模型效果。
+- [basic_language_model_roberta_small.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_small.py)：测试Roberta的MLM模型效果。
 - [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
 - [basic_language_model_ernie.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_ernie.py)：测试百度文心ERNIE的MLM模型效果。
 - [basic_language_model_GAU_alpha.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_GAU_alpha.py)：测试[GAU-alpha](https://github.com/ZhuiyiTechnology/GAU-alpha)的MLM模型效果。
@@ -30,7 +33,16 @@
 - [basic_language_model_albert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_albert.py): 测试[albert_chinese](https://github.com/brightmart/albert_zh)模型。
 - [basic_language_model_llama.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_llama.py): 测试[llama](https://github.com/facebookresearch/llama)模型。
 
+- [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
+-
+
+
+- [basic_language_model_roberta_english.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/basic/basic_language_model_roberta_english.py)：测试英文版Roberta的MLM模型效果。
+-
+
+
 ## 文本分类
+
 - [task_sentence_similarity_lcqmc.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_classfication/task_sentence_similarity_lcqmc.py)：句子对分类任务。
 - [task_sentiment_classification.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_classfication/task_sentiment_classification.py)：情感分类任务，bert做简单文本分类
 - [task_sentiment_classification_albert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_classfication/task_sentiment_classification_albert.py)：情感分类任务，加载ALBERT模型。
@@ -49,6 +61,7 @@
 - [Tianchi_News_Classification](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_classfication/Tianchi_News_Classification)：天池零基础入门NLP-新闻分类Top1方案复现
 
 ## 序列标注
+
 - [task_sequence_labeling_ner_efficient_global_pointer.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sequence_labeling/task_sequence_labeling_ner_efficient_global_pointer.py)：ner例子，efficient_global_pointer的pytorch实现
 - [task_sequence_labeling_ner_global_pointer.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sequence_labeling/task_sequence_labeling_ner_global_pointer.py)：ner例子，global_pointer的pytorch实现
 - [task_sequence_labeling_ner_crf.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sequence_labeling/task_sequence_labeling_ner_crf.py)：ner例子，bert+crf
@@ -65,6 +78,7 @@
 - [task_sequence_labeling_cws_crf.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sequence_labeling/task_sequence_labeling_cws_crf.py)：crf分词例子
 
 ## 文本表示
+
 - [task_sentence_embedding_unsup_bert_whitening.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_embedding/task_sentence_embedding_unsup_bert_whitening.py)：参考[bert_whitening](https://github.com/bojone/BERT-whitening)
 - [task_sentence_embedding_unsup_CT.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_embedding/task_sentence_embedding_unsup_CT.py)：参考[SentenceTransformer](https://www.sbert.net/index.html)
 - [task_sentence_embedding_unsup_CT_In-Batch_Negatives.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_embedding/task_sentence_embedding_unsup_CT_In-Batch_Negatives.py)：参考[SentenceTransformer](https://www.sbert.net/index.html)
@@ -83,6 +97,7 @@
 - [FinanceFAQ](https://github.com/Tongjilibo/bert4torch/blob/master/examples/sentence_embedding/FinanceFAQ)：金融领域FAQ两阶段(召回+排序)pipline
 
 ## 关系提取
+
 - [task_relation_extraction_CasRel.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/relation_extraction/task_relation_extraction_CasRel.py)：结合BERT以及自行设计的“半指针-半标注”结构来做[关系抽取](https://kexue.fm/archives/7161)。
 - [task_relation_extraction_gplinker.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/relation_extraction/task_relation_extraction_gplinker.py)：结合GlobalPointer做关系抽取[GPLinker](https://kexue.fm/archives/8888)。
 - [task_relation_extraction_tplinker.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/relation_extraction/task_relation_extraction_tplinker.py)：tplinker关系抽取[TPLinker](https://github.com/131250208/TPlinker-joint-extraction)。
@@ -91,6 +106,7 @@
 - [task_relation_extraction_PGRC.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/relation_extraction/task_relation_extraction_PGRC.py)：[PGRC](https://github.com/hy-struggle/PRGC)来做关系提取。
 
 ## 文本生成
+
 - [task_seq2seq_autotitle_csl_unilm.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/seq2seq/task_seq2seq_autotitle_csl_unilm.py)：通过[UniLM](https://kexue.fm/archives/6933)式的Seq2Seq模型来做新闻标题生成。
 - [task_seq2seq_autotitle_csl_bart.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/seq2seq/task_seq2seq_autotitle_csl_bart.py)：通过BART来做新闻标题生成
 - [task_seq2seq_autotitle_csl_uer_t5.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/seq2seq/task_seq2seq_autotitle_csl_uer_t5.py)：通过T5来做新闻标题生成，用的[uer-t5-small](https://huggingface.co/uer/t5-small-chinese-cluecorpussmall)
@@ -106,6 +122,7 @@
 - [task_promptclue_finetune.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/seq2seq/task_promptclue_finetune.py)：基于promptclue-base-v1.5的微调
 
 ## 训练Trick
+
 - [task_sentiment_adversarial_training.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/training_trick/task_sentiment_adversarial_training.py)：通过对抗训练，虚拟对抗训练，梯度惩罚等措施来提升分类效果。
 - [task_sentiment_virtual_adversarial_training.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/training_trick/task_sentiment_virtual_adversarial_training.py)：通过半监督的虚拟对抗训练等措施来提升分类效果。
 - [task_sentiment_UDA.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/training_trick/task_sentiment_UDA.py)：通过[UDA](https://arxiv.org/abs/1904.12848)半监督学习提升分类效果，在原来Losss上加一致性损失。
@@ -120,11 +137,13 @@
 - [accelerate](https://github.com/Tongjilibo/bert4torch/blob/master/examples/training_trick/accelerate)：配合accelerate包使用
 
 ## 预训练
+
 - [roberta_pretrain](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/roberta_pretrain)：roberta的mlm预训练，数据生成代码和训练代码
 - [simbert_v2_pretrain](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/simbert_v2_pretrain)：相似问生成，数据增广，三个步骤：1-[弱监督](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/simbert_v2_pretrain/simbert_v2_stage1.py)，2-[蒸馏](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/simbert_v2_pretrain/simbert_v2_stage2.py)，3-[有监督](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/simbert_v2_pretrain/simbert_v2_supervised.py)，参考[SimBERT-V2](https://kexue.fm/archives/8454)
 - [gpt_lm_pretrain](https://github.com/Tongjilibo/bert4torch/blob/master/examples/pretrain/gpt_lm_pretrain)：gpt的lm预训练
 
 ## 模型部署
+
 - [basic_simple_web_serving_simbert.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/serving/basic_simple_web_serving_simbert.py): 测试自带的WebServing（将模型转化为Web接口）。
 - [task_bert_cls_onnx.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/serving/task_bert_cls_onnx.py)：ONNX转换bert权重
 - [task_bert_cls_onnx_tensorrt.md](https://github.com/Tongjilibo/bert4torch/blob/master/examples/serving/task_bert_cls_onnx_tensorrt.md)：ONNX+Tensorrt部署
@@ -133,6 +152,7 @@
 - [triton](https://github.com/Tongjilibo/bert4torch/blob/master/examples/serving/triton)：triton部署
 
 ## 其他
+
 - [task_conditional_language_model.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/others/task_conditional_language_model.py)：结合BERT+[ConditionalLayerNormalization](https://kexue.fm/archives/7124)做条件语言模型。
 - [task_language_model.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/others/task_language_model.py)：加载BERT的预训练权重做无条件语言模型，效果上等价于GPT。
 - [task_iflytek_bert_of_theseus.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/others/task_iflytek_bert_of_theseus.py)：通过[BERT-of-Theseus](https://kexue.fm/archives/7575)来进行模型压缩。
@@ -141,132 +161,152 @@
 - [task_event_extraction_gplinker.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/others/task_event_extraction_gplinker.py)：gplinker来做事件提取
 
 ## 教程
+
 - [Tutorials](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/Tutorials)：教程说明文档。
 - [tutorials_custom_fit_progress.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/tutorials_custom_fit_progress.py)：教程，自定义训练过程fit函数（集成了训练进度条展示），可用于满足如半精度，梯度裁剪等高阶需求。
 - [tutorials_load_transformers_model.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/tutorials_load_transformers_model.py)：教程，加载transformer包中模型，可以使用bert4torch中继承的对抗训练等trick。
 - [tutorials_small_tips.py](https://github.com/Tongjilibo/bert4torch/blob/master/examples/tutorials/tutorials_small_tips.py)：教程，常见的一些tips集合。
 
 # 二、数据集
-| 数据集名称 | 用途 | 下载链接 |
-|  ----  |  ----  |  ----  |
-|人民日报数据集|实体识别|[china-people-daily-ner-corpus](http://s3.bmio.net/kashgari/china-people-daily-ner-corpus.tar.gz)
-|百度关系抽取|关系抽取|[BD_Knowledge_Extraction](http://ai.baidu.com/broad/download?dataset=sked)
-|Sentiment|情感分类|[Sentiment](https://github.com/bojone/bert4keras/blob/master/examples/datasets/sentiment.zip)
-|THUCNews|文本分类、文本生成|[THUCNews](http://thuctc.thunlp.org/#%E4%B8%AD%E6%96%87%E6%96%87%E6%9C%AC%E5%88%86%E7%B1%BB%E6%95%B0%E6%8D%AE%E9%9B%86THUCNews)
-|ATEC| 文本相似度 | [ATEC](https://github.com/IceFlameWorm/NLP_Datasets/tree/master/ATEC)
-|BQ| 文本相似度 | [BQ](http://icrc.hitsz.edu.cn/info/1037/1162.htm)
-|LCQMC| 文本相似度 | [LCQMC](http://icrc.hitsz.edu.cn/Article/show/171.html)
-|PAWSX| 文本相似度 | [PAWSX](https://arxiv.org/abs/1908.11828)
-|STS-B| 文本相似度 | [STS-B](https://github.com/pluto-junzeng/CNSD)
-|CSL|文本生成|[CSL](https://github.com/CLUEbenchmark/CLGE)|
+
+
+| 数据集名称     | 用途               | 下载链接                                                                                                                        |
+| ---------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| 人民日报数据集 | 实体识别           | [china-people-daily-ner-corpus](http://s3.bmio.net/kashgari/china-people-daily-ner-corpus.tar.gz)                               |
+| 百度关系抽取   | 关系抽取           | [BD_Knowledge_Extraction](http://ai.baidu.com/broad/download?dataset=sked)                                                      |
+| Sentiment      | 情感分类           | [Sentiment](https://github.com/bojone/bert4keras/blob/master/examples/datasets/sentiment.zip)                                   |
+| THUCNews       | 文本分类、文本生成 | [THUCNews](http://thuctc.thunlp.org/#%E4%B8%AD%E6%96%87%E6%96%87%E6%9C%AC%E5%88%86%E7%B1%BB%E6%95%B0%E6%8D%AE%E9%9B%86THUCNews) |
+| ATEC           | 文本相似度         | [ATEC](https://github.com/IceFlameWorm/NLP_Datasets/tree/master/ATEC)                                                           |
+| BQ             | 文本相似度         | [BQ](http://icrc.hitsz.edu.cn/info/1037/1162.htm)                                                                               |
+| LCQMC          | 文本相似度         | [LCQMC](http://icrc.hitsz.edu.cn/Article/show/171.html)                                                                         |
+| PAWSX          | 文本相似度         | [PAWSX](https://arxiv.org/abs/1908.11828)                                                                                       |
+| STS-B          | 文本相似度         | [STS-B](https://github.com/pluto-junzeng/CNSD)                                                                                  |
+| CSL            | 文本生成           | [CSL](https://github.com/CLUEbenchmark/CLGE)                                                                                    |
 
 # 三、指标测试
+
 ## 1. 文本分类
+
 ### 1.1 不同预训练模型的指标对比
+
 - [情感分类数据集](https://github.com/bojone/bert4keras/blob/master/examples/datasets/sentiment.zip)+cls位分类
 
-| solution | epoch | valid_acc | test_acc | comment | 
-| ---- | ---- | ---- | ---- | ---- | 
-| albert_small | 10/10 | 94.46 | 93.98 | small版本 | 
-| bert | 6/10 | 94.72 | 94.11 | —— | 
-| robert | 4/10 | 94.77 | 94.64 | —— | 
-| nezha | 7/10 | 95.07 | 94.72 | —— | 
-| xlnet | 6/10 | 95.07 | 94.77 | —— | 
-| electra | 10/10 | 94.94 | 94.78 | —— | 
-| roformer | 9/10 | 94.85 | 94.42 | —— | 
-| roformer_v2 | 3/10 | 95.78 | 96.09 | —— | 
-| gau_alpha | 2/10 | 95.25 | 94.46 | —— | 
-| deberta_v2 | (10/2/5)/10 | 94.55/95.16/94.85 | 94.99/94.68/94.33 | 分别为97M/320M/710M, 97M的transformer版本指标为94.90/94.81| 
+
+| solution     | epoch       | valid_acc         | test_acc          | comment                                                    |
+| -------------- | ------------- | ------------------- | ------------------- | ------------------------------------------------------------ |
+| albert_small | 10/10       | 94.46             | 93.98             | small版本                                                  |
+| bert         | 6/10        | 94.72             | 94.11             | ——                                                       |
+| robert       | 4/10        | 94.77             | 94.64             | ——                                                       |
+| nezha        | 7/10        | 95.07             | 94.72             | ——                                                       |
+| xlnet        | 6/10        | 95.07             | 94.77             | ——                                                       |
+| electra      | 10/10       | 94.94             | 94.78             | ——                                                       |
+| roformer     | 9/10        | 94.85             | 94.42             | ——                                                       |
+| roformer_v2  | 3/10        | 95.78             | 96.09             | ——                                                       |
+| gau_alpha    | 2/10        | 95.25             | 94.46             | ——                                                       |
+| deberta_v2   | (10/2/5)/10 | 94.55/95.16/94.85 | 94.99/94.68/94.33 | 分别为97M/320M/710M, 97M的transformer版本指标为94.90/94.81 |
 
 ### 1.2 不同trick下的指标对比
+
 - trick测试+[情感分类数据集](https://github.com/bojone/bert4keras/blob/master/examples/datasets/sentiment.zip)+cls分类+无segment_input
 
-| solution | epoch | valid_acc | test_acc | comment | 
-| ---- | ---- | ---- | ---- | ---- | 
-| bert | 10/10 | 94.90 | 94.78 | —— | 
-| fgm | 4/10 | 95.34 | 94.99 | —— | 
-| pgd | 6/10 | 95.34 | 94.64 | —— | 
-| gradient_penalty | 7/10 | 95.07 | 94.81 | —— | 
-| vat | 8/10 | 95.21 | 95.03 | —— | 
-| ema | 7/10 | 95.21 | 94.86 | —— | 
-| ema+warmup | 7/10 | 95.51 | 95.12 | —— | 
-| mix_up | 6/10 | 95.12 | 94.42 | —— | 
-| R-drop | 9/10 | 95.25 | 94.94 | —— | 
-| UDA | 8/10 | 94.90 | 95.56 | —— | 
-| semi-vat | 10/10 | 95.34 | 95.38 | —— |
-| temporal_ensembling | 8/10 | 94.94 | 94.90 | —— |
+
+| solution            | epoch | valid_acc | test_acc | comment |
+| --------------------- | ------- | ----------- | ---------- | --------- |
+| bert                | 10/10 | 94.90     | 94.78    | ——    |
+| fgm                 | 4/10  | 95.34     | 94.99    | ——    |
+| pgd                 | 6/10  | 95.34     | 94.64    | ——    |
+| gradient_penalty    | 7/10  | 95.07     | 94.81    | ——    |
+| vat                 | 8/10  | 95.21     | 95.03    | ——    |
+| ema                 | 7/10  | 95.21     | 94.86    | ——    |
+| ema+warmup          | 7/10  | 95.51     | 95.12    | ——    |
+| mix_up              | 6/10  | 95.12     | 94.42    | ——    |
+| R-drop              | 9/10  | 95.25     | 94.94    | ——    |
+| UDA                 | 8/10  | 94.90     | 95.56    | ——    |
+| semi-vat            | 10/10 | 95.34     | 95.38    | ——    |
+| temporal_ensembling | 8/10  | 94.94     | 94.90    | ——    |
 
 ## 2. 序列标注
+
 - [人民日报数据集](http://s3.bmio.net/kashgari/china-people-daily-ner-corpus.tar.gz)+bert预训练模型
 - valid集指标
 
-| solution | epoch | f1_token | f1_entity | comment | 
-| ---- | ---- | ---- | ---- | ---- | 
-| bert+crf | 18/20 | 96.89 | 96.05 | —— |
-| bert+crf+init | 18/20 | 96.93 | 96.08 | 用训练数据初始化crf权重 | 
-| bert+crf+freeze | 11/20 | 96.89 | 96.13 | 用训练数据生成crf权重(不训练) |
-| bert+cascade+crf | 5/20 | 98.10 | 96.26 | crf类别少所以f1_token偏高 | 
-| bert+crf+posseg | 13/20 | 97.32 | 96.55 | 加了词性输入 | 
-| bert+global_pointer | 18/20 | —— | 95.66 | —— | 
-| bert+efficient_global_pointer | 17/20 | —— | 96.55 | —— | 
-| bert+mrc | 7/20 | —— | 95.75 | —— |
-| bert+span | 13/20 | —— | 96.31 | —— |
-| bert+tplinker_plus | 20/20 | —— | 95.71 | 长度限制明显 |
-| uie | 20/20 | —— | 96.57 | zeroshot:f1=60.8, fewshot-100样本:f1=85.82, 200样本:f1=86.40 |
-| W2NER | 18/20 | 97.37 | 96.32 | 对显存要求较高 |
-| CNN_Nested_NER |19/20|98.06|96.11|  |
-| LEAR | 8/20 | —— | 96.52 |  |
+
+| solution                      | epoch | f1_token | f1_entity | comment                                                      |
+| ------------------------------- | ------- | ---------- | ----------- | -------------------------------------------------------------- |
+| bert+crf                      | 18/20 | 96.89    | 96.05     | ——                                                         |
+| bert+crf+init                 | 18/20 | 96.93    | 96.08     | 用训练数据初始化crf权重                                      |
+| bert+crf+freeze               | 11/20 | 96.89    | 96.13     | 用训练数据生成crf权重(不训练)                                |
+| bert+cascade+crf              | 5/20  | 98.10    | 96.26     | crf类别少所以f1_token偏高                                    |
+| bert+crf+posseg               | 13/20 | 97.32    | 96.55     | 加了词性输入                                                 |
+| bert+global_pointer           | 18/20 | ——     | 95.66     | ——                                                         |
+| bert+efficient_global_pointer | 17/20 | ——     | 96.55     | ——                                                         |
+| bert+mrc                      | 7/20  | ——     | 95.75     | ——                                                         |
+| bert+span                     | 13/20 | ——     | 96.31     | ——                                                         |
+| bert+tplinker_plus            | 20/20 | ——     | 95.71     | 长度限制明显                                                 |
+| uie                           | 20/20 | ——     | 96.57     | zeroshot:f1=60.8, fewshot-100样本:f1=85.82, 200样本:f1=86.40 |
+| W2NER                         | 18/20 | 97.37    | 96.32     | 对显存要求较高                                               |
+| CNN_Nested_NER                | 19/20 | 98.06    | 96.11     |                                                              |
+| LEAR                          | 8/20  | ——     | 96.52     |                                                              |
 
 ## 3. 文本表示
+
 ### 3.1 无监督语义相似度
+
 - bert预训练模型 + 无监督finetune + cls位句向量(PromptBert除外)
 - 五个中文数据集 + 5个epoch取最优值 + valid的spearmanr相关系数
 - 继续finetune, 部分数据集有小幅提升
 - 实验显示dropout_rate对结果影响较大
 
-|     solution    |   ATEC  |  BQ  |  LCQMC  |  PAWSX  |  STS-B  |   comment   |
-|       ----      |   ----  | ---- |   ----  |   ----  |   ----  |     ----    |
-| Bert-whitening  |  26.79  | 31.81|  56.34  |  17.22  |  67.45  | cls+不降维   |
-|        CT       |  30.65  | 44.50|  68.67  |  16.20  |  69.27  | dropout=0.1, 收敛慢跑了10个epoch |
-| CT_In_Batch_Neg |  32.47  | 47.09|  68.56  |  27.50  |  74.00  | dropout=0.1 |
-|       TSDAE     |    ——   | 46.65|  65.30  |  12.54  |    ——   | dropout=0.1, ——表示该指标异常未记录 |
-|      SimCSE     |  33.90  | 50.29|  71.81  |  13.14  |  71.09  | dropout=0.3 |
-|      ESimCSE    |  34.05  | 50.54|  71.58  |  12.53  |  71.27  | dropout=0.3 |
-|      DiffSCE    |  33.04  | 48.17|  71.51  |  12.91  |  71.10  | dropout=0.3, 没啥效果 |
-|    PromptBert   |  33.98  | 49.89|  73.18  |  13.30  |  73.42  | dropout=0.3 |
+
+| solution        | ATEC  | BQ    | LCQMC | PAWSX | STS-B | comment                               |
+| ----------------- | ------- | ------- | ------- | ------- | ------- | --------------------------------------- |
+| Bert-whitening  | 26.79 | 31.81 | 56.34 | 17.22 | 67.45 | cls+不降维                            |
+| CT              | 30.65 | 44.50 | 68.67 | 16.20 | 69.27 | dropout=0.1, 收敛慢跑了10个epoch      |
+| CT_In_Batch_Neg | 32.47 | 47.09 | 68.56 | 27.50 | 74.00 | dropout=0.1                           |
+| TSDAE           | ——  | 46.65 | 65.30 | 12.54 | ——  | dropout=0.1, ——表示该指标异常未记录 |
+| SimCSE          | 33.90 | 50.29 | 71.81 | 13.14 | 71.09 | dropout=0.3                           |
+| ESimCSE         | 34.05 | 50.54 | 71.58 | 12.53 | 71.27 | dropout=0.3                           |
+| DiffSCE         | 33.04 | 48.17 | 71.51 | 12.91 | 71.10 | dropout=0.3, 没啥效果                 |
+| PromptBert      | 33.98 | 49.89 | 73.18 | 13.30 | 73.42 | dropout=0.3                           |
 
 ### 3.2 有监督语义相似度
+
 - bert预训练模型 + 训练数据finetune + cls位句向量
 - 五个中文数据集 + 5个epoch取最优值 + valid/test的spearmanr相关系数
 - STS-B任务是5分类，其余是2分类
 
-|      solution     |     ATEC    |     BQ      |    LCQMC    |    PAWSX    |    STS-B    |      comment     |
-|        ----       |     ----    |    ----     |     ----    |     ----    |     ----    |        ----      |
-|       CoSENT      |50.61 / 49.81|72.84 / 71.61|77.79 / 78.74|55.00 / 56.00|83.48 / 80.06|                  |
-|  ContrastiveLoss  |50.02 / 49.19|72.52 / 70.98|77.49 / 78.27|58.21 / 57.65|69.87 / 68.58|   STS-B转为2分类  |
-|      InfoNCE      |47.77 / 46.99|69.86 / 68.14|71.74 / 74.54|52.82 / 54.21|83.31 / 78.72|   STS-B转为2分类  |
-|concat CrossEntropy|48.71 / 47.62|72.16 / 70.07|78.44 / 78.77|51.46 / 52.28|61.31 / 56.62|   STS-B转为2分类  |
-|   CosineMSELoss   |46.89 / 45.86|72.27 / 71.35|75.29 / 77.19|54.92 / 54.35|81.64 / 77.76|  STS-B标准化到0-1 |
+
+| solution            | ATEC          | BQ            | LCQMC         | PAWSX         | STS-B         | comment          |
+| --------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | ------------------ |
+| CoSENT              | 50.61 / 49.81 | 72.84 / 71.61 | 77.79 / 78.74 | 55.00 / 56.00 | 83.48 / 80.06 |                  |
+| ContrastiveLoss     | 50.02 / 49.19 | 72.52 / 70.98 | 77.49 / 78.27 | 58.21 / 57.65 | 69.87 / 68.58 | STS-B转为2分类   |
+| InfoNCE             | 47.77 / 46.99 | 69.86 / 68.14 | 71.74 / 74.54 | 52.82 / 54.21 | 83.31 / 78.72 | STS-B转为2分类   |
+| concat CrossEntropy | 48.71 / 47.62 | 72.16 / 70.07 | 78.44 / 78.77 | 51.46 / 52.28 | 61.31 / 56.62 | STS-B转为2分类   |
+| CosineMSELoss       | 46.89 / 45.86 | 72.27 / 71.35 | 75.29 / 77.19 | 54.92 / 54.35 | 81.64 / 77.76 | STS-B标准化到0-1 |
 
 ## 4. 关系提取
+
 - [百度关系提取数据集](http://ai.baidu.com/broad/download?dataset=sked)
 
-|      solution     |     f1    |    comment  |
-|        ----       |    ----   |    ----     |
-|       CasRel      |   81.87   |             |
-|     gplinker      |   82.38   |             |
-|     tplinker      |   74.49   |  seq_len=64, 未完全收敛 |
-|    tplinker_plus  |   79.30   |  seq_len=64 |
-|       SPN4RE      |   77.53   |             |
-|        PGRC       |   80.36   |   训练很慢   |
+
+| solution      | f1    | comment                |
+| --------------- | ------- | ------------------------ |
+| CasRel        | 81.87 |                        |
+| gplinker      | 82.38 |                        |
+| tplinker      | 74.49 | seq_len=64, 未完全收敛 |
+| tplinker_plus | 79.30 | seq_len=64             |
+| SPN4RE        | 77.53 |                        |
+| PGRC          | 80.36 | 训练很慢               |
 
 ## 5. 文本生成
+
 - [CSL数据集](https://github.com/CLUEbenchmark/CLGE)，注意是训练集1万左右的版本，分别dev/test指标
 
-| solution |   Rouge-L   |   Rouge-1   |   Rouge-2   |     BLEU    |    comment  |
-|   ----   |     ----    |     ----    |     ----    |     ----    |    ----     |
-|bert+unlim|63.65 / 63.01|66.25 / 66.34|54.48 / 54.81|44.21 / 44.60|             |
-|   bart   |64.62 / 64.99|67.72 / 68.40|56.08 / 57.26|46.15 / 47.67|             |
-|   mt5    |67.67 / 65.98|70.39 / 69.36|59.60 / 59.05|50.34 / 50.11|             |
-|t5_pegasus|66.07 / 66.11|68.94 / 69.61|57.12 / 58.38|46.14 / 47.95|             |
-|  uer_t5  |63.59 / 63.11|66.56 / 66.48|54.65 / 54.82|44.27 / 44.60|             |
+
+| solution   | Rouge-L       | Rouge-1       | Rouge-2       | BLEU          | comment |
+| ------------ | --------------- | --------------- | --------------- | --------------- | --------- |
+| bert+unlim | 63.65 / 63.01 | 66.25 / 66.34 | 54.48 / 54.81 | 44.21 / 44.60 |         |
+| bart       | 64.62 / 64.99 | 67.72 / 68.40 | 56.08 / 57.26 | 46.15 / 47.67 |         |
+| mt5        | 67.67 / 65.98 | 70.39 / 69.36 | 59.60 / 59.05 | 50.34 / 50.11 |         |
+| t5_pegasus | 66.07 / 66.11 | 68.94 / 69.61 | 57.12 / 58.38 | 46.14 / 47.95 |         |
+| uer_t5     | 63.59 / 63.11 | 66.56 / 66.48 | 54.65 / 54.82 | 44.27 / 44.60 |         |

--- a/examples/basic/basic_language_model_roberta_small.py
+++ b/examples/basic/basic_language_model_roberta_small.py
@@ -1,0 +1,32 @@
+# 基础测试：苏神 or UER  roberta-small/tiny mlm预测
+# 使用的时候需要with_pool=False, 否则会有warnings, CLS的输出直接按last_hidden_state[:, 0]取得
+
+import torch
+from bert4torch.models import build_transformer_model
+from bert4torch.tokenizers import Tokenizer
+
+
+# 加载模型，
+base_path = './pt_chinese_roberta_L-6_H-512'
+dict_path = base_path + '/vocab.txt'
+config_path = base_path + '/config.json'
+checkpoint_path = base_path + '/pytorch_model.bin'
+
+# 分词器
+tokenizer = Tokenizer(dict_path, do_lower_case=True)
+
+# 模型
+model = build_transformer_model(config_path,
+                                checkpoint_path,
+                                with_mlm='softmax',
+                                segment_vocab_size=0)
+
+
+if __name__ == '__main__':
+    text = '中国的首都是[MASK]京'
+
+    token_ids, _ = tokenizer.encode(text)
+    token_ids = torch.tensor([token_ids])
+
+    _, probas = model.predict([token_ids])
+    print(tokenizer.decode(torch.argmax(probas[0, 7:8], dim=-1).numpy()))

--- a/examples/convert_script/convert_roberta-small.py
+++ b/examples/convert_script/convert_roberta-small.py
@@ -1,0 +1,74 @@
+# roberta-small/tiny预训练模型tensorflow转pytorch
+# 源项目：https://github.com/ZhuiyiTechnology/pretrained-models
+# torch版本： https://huggingface.co/uer UER旗下各个缩微版roberta-small/tiny/mini(注意层规格与苏神的是不一样的)
+# 注意苏神版本的roberta-small/tiny的ckpt无pooler层, 区别于bert base转换脚本需要删除pooler层
+# 使用的时候需要with_pool=False, 否则会有warnings, CLS的输出直接按last_hidden_state[:, 0]取得
+
+# PS: 暂时不支持苏神的roberta-small/tiny key+版本, 暂时列入todo list
+
+import torch
+import tensorflow as tf
+import json
+
+# 也可以从huggingface下第三方转换的https://huggingface.co/peterchou/simbert-chinese-base
+tf_dir = './tf_chinese_roberta_L-6_H-384-384_A-12/'
+tf_path = tf_dir + 'bert_model.ckpt'
+torch_path = './pt_chinese_roberta_L-6_H-384-384_A-12/pytorch_model.bin'
+
+
+with open(tf_dir + 'bert_config.json', 'r') as f:
+    config = json.load(f)
+    num_layers = config['num_hidden_layers']
+
+torch_state_dict = {}
+
+prefix = 'bert'
+mapping = {
+'bert/embeddings/word_embeddings':  f'{prefix}.embeddings.word_embeddings.weight',
+'bert/embeddings/position_embeddings':  f'{prefix}.embeddings.position_embeddings.weight',
+'bert/embeddings/token_type_embeddings': f'{prefix}.embeddings.token_type_embeddings.weight',
+'bert/embeddings/LayerNorm/beta': f'{prefix}.embeddings.LayerNorm.bias',
+'bert/embeddings/LayerNorm/gamma': f'{prefix}.embeddings.LayerNorm.weight',
+'cls/predictions/transform/dense/kernel': 'cls.predictions.transform.dense.weight##',
+'cls/predictions/transform/dense/bias': 'cls.predictions.transform.dense.bias',
+'cls/predictions/transform/LayerNorm/beta': 'cls.predictions.transform.LayerNorm.bias',
+'cls/predictions/transform/LayerNorm/gamma': 'cls.predictions.transform.LayerNorm.weight',
+'cls/predictions/output_bias': 'cls.predictions.bias'}
+
+if ('embedding_size' in config) and (config['embedding_size'] != config['hidden_size']):
+    mapping.update({'bert/encoder/embedding_hidden_mapping_in/kernel': f'{prefix}.encoder.embedding_hidden_mapping_in.weight##',
+    'bert/encoder/embedding_hidden_mapping_in/bias': f'{prefix}.encoder.embedding_hidden_mapping_in.bias'})
+
+for i in range(num_layers):
+    prefix_i = f'{prefix}.encoder.layer.%d.' % i
+    mapping.update({
+        f'bert/encoder/layer_{i}/attention/self/query/kernel': prefix_i + 'attention.self.query.weight##',  # 转置标识
+        f'bert/encoder/layer_{i}/attention/self/query/bias': prefix_i + 'attention.self.query.bias',
+        f'bert/encoder/layer_{i}/attention/self/key/kernel': prefix_i + 'attention.self.key.weight##',
+        f'bert/encoder/layer_{i}/attention/self/key/bias': prefix_i + 'attention.self.key.bias',
+        f'bert/encoder/layer_{i}/attention/self/value/kernel': prefix_i + 'attention.self.value.weight##',
+        f'bert/encoder/layer_{i}/attention/self/value/bias': prefix_i + 'attention.self.value.bias',
+        f'bert/encoder/layer_{i}/attention/output/dense/kernel': prefix_i + 'attention.output.dense.weight##',
+        f'bert/encoder/layer_{i}/attention/output/dense/bias': prefix_i + 'attention.output.dense.bias',
+        f'bert/encoder/layer_{i}/attention/output/LayerNorm/beta': prefix_i + 'attention.output.LayerNorm.bias',
+        f'bert/encoder/layer_{i}/attention/output/LayerNorm/gamma': prefix_i + 'attention.output.LayerNorm.weight',
+        f'bert/encoder/layer_{i}/intermediate/dense/kernel': prefix_i + 'intermediate.dense.weight##',
+        f'bert/encoder/layer_{i}/intermediate/dense/bias': prefix_i + 'intermediate.dense.bias',
+        f'bert/encoder/layer_{i}/output/dense/kernel': prefix_i + 'output.dense.weight##',
+        f'bert/encoder/layer_{i}/output/dense/bias': prefix_i + 'output.dense.bias',
+        f'bert/encoder/layer_{i}/output/LayerNorm/beta': prefix_i + 'output.LayerNorm.bias',
+        f'bert/encoder/layer_{i}/output/LayerNorm/gamma': prefix_i + 'output.LayerNorm.weight'
+    })
+
+
+for key, value in mapping.items():
+    ts = tf.train.load_variable(tf_path, key)
+    if value.endswith('##'):
+        value = value.replace('##', '')
+        torch_state_dict[value] = torch.from_numpy(ts).T
+    else:
+        torch_state_dict[value] = torch.from_numpy(ts)
+torch_state_dict['cls.predictions.decoder.weight'] = torch_state_dict[f'{prefix}.embeddings.word_embeddings.weight']
+torch_state_dict['cls.predictions.decoder.bias'] = torch_state_dict['cls.predictions.bias']
+
+torch.save(torch_state_dict, torch_path)

--- a/examples/convert_script/convert_roformer-sim.py
+++ b/examples/convert_script/convert_roformer-sim.py
@@ -1,0 +1,69 @@
+# roformer-sim(simbert v2)预训练模型tensorflow转pytorch
+# 源项目：https://github.com/ZhuiyiTechnology/roformer-sim
+# 跟simbert(v1)最主要的不同是不需要加载位置编码的部分,苏神ckpt也同样无该部分,加载进模型后使用rope位置编码
+
+import torch
+import tensorflow as tf
+import json
+
+tf_dir = 'F:/Projects/pretrain_ckpt/simbert/[sushen_tf_base]--chinese_roformer-sim-char_L-12_H-768_A-12/'
+tf_path = tf_dir + 'bert_model.ckpt'
+torch_path = 'F:/Projects/pretrain_ckpt/simbert/[sushen_torch_base]--chinese_roformer-sim-char_L-12_H-768_A-12/pytorch_model.bin'
+
+with open(tf_dir + 'bert_config.json', 'r') as f:
+    config = json.load(f)
+    num_layers = config['num_hidden_layers']
+
+torch_state_dict = {}
+
+prefix = 'roformer'
+mapping = {
+'bert/embeddings/word_embeddings':  f'{prefix}.embeddings.word_embeddings.weight',
+'bert/embeddings/token_type_embeddings': f'{prefix}.embeddings.token_type_embeddings.weight',
+'bert/embeddings/LayerNorm/beta': f'{prefix}.embeddings.LayerNorm.bias',
+'bert/embeddings/LayerNorm/gamma': f'{prefix}.embeddings.LayerNorm.weight',
+'cls/predictions/transform/dense/kernel': 'cls.predictions.transform.dense.weight##',
+'cls/predictions/transform/dense/bias': 'cls.predictions.transform.dense.bias',
+'cls/predictions/transform/LayerNorm/beta': 'cls.predictions.transform.LayerNorm.bias',
+'cls/predictions/transform/LayerNorm/gamma': 'cls.predictions.transform.LayerNorm.weight',
+'cls/predictions/output_bias': 'cls.predictions.bias',
+'bert/pooler/dense/kernel': f'{prefix}.pooler.dense.weight##',
+'bert/pooler/dense/bias': f'{prefix}.pooler.dense.bias'}
+
+if ('embedding_size' in config) and (config['embedding_size'] != config['hidden_size']):
+    mapping.update({'bert/encoder/embedding_hidden_mapping_in/kernel': f'{prefix}.encoder.embedding_hidden_mapping_in.weight##',
+    'bert/encoder/embedding_hidden_mapping_in/bias': f'{prefix}.encoder.embedding_hidden_mapping_in.bias'})
+
+for i in range(num_layers):
+    prefix_i = f'{prefix}.encoder.layer.%d.' % i
+    mapping.update({
+        f'bert/encoder/layer_{i}/attention/self/query/kernel': prefix_i + 'attention.self.query.weight##',  # 转置标识
+        f'bert/encoder/layer_{i}/attention/self/query/bias': prefix_i + 'attention.self.query.bias',
+        f'bert/encoder/layer_{i}/attention/self/key/kernel': prefix_i + 'attention.self.key.weight##',
+        f'bert/encoder/layer_{i}/attention/self/key/bias': prefix_i + 'attention.self.key.bias',
+        f'bert/encoder/layer_{i}/attention/self/value/kernel': prefix_i + 'attention.self.value.weight##',
+        f'bert/encoder/layer_{i}/attention/self/value/bias': prefix_i + 'attention.self.value.bias',
+        f'bert/encoder/layer_{i}/attention/output/dense/kernel': prefix_i + 'attention.output.dense.weight##',
+        f'bert/encoder/layer_{i}/attention/output/dense/bias': prefix_i + 'attention.output.dense.bias',
+        f'bert/encoder/layer_{i}/attention/output/LayerNorm/beta': prefix_i + 'attention.output.LayerNorm.bias',
+        f'bert/encoder/layer_{i}/attention/output/LayerNorm/gamma': prefix_i + 'attention.output.LayerNorm.weight',
+        f'bert/encoder/layer_{i}/intermediate/dense/kernel': prefix_i + 'intermediate.dense.weight##',
+        f'bert/encoder/layer_{i}/intermediate/dense/bias': prefix_i + 'intermediate.dense.bias',
+        f'bert/encoder/layer_{i}/output/dense/kernel': prefix_i + 'output.dense.weight##',
+        f'bert/encoder/layer_{i}/output/dense/bias': prefix_i + 'output.dense.bias',
+        f'bert/encoder/layer_{i}/output/LayerNorm/beta': prefix_i + 'output.LayerNorm.bias',
+        f'bert/encoder/layer_{i}/output/LayerNorm/gamma': prefix_i + 'output.LayerNorm.weight'
+    })
+
+
+for key, value in mapping.items():
+    ts = tf.train.load_variable(tf_path, key)
+    if value.endswith('##'):
+        value = value.replace('##', '')
+        torch_state_dict[value] = torch.from_numpy(ts).T
+    else:
+        torch_state_dict[value] = torch.from_numpy(ts)
+torch_state_dict['cls.predictions.decoder.weight'] = torch_state_dict[f'{prefix}.embeddings.word_embeddings.weight']
+torch_state_dict['cls.predictions.decoder.bias'] = torch_state_dict['cls.predictions.bias']
+
+torch.save(torch_state_dict, torch_path)

--- a/examples/convert_script/convert_simbert.py
+++ b/examples/convert_script/convert_simbert.py
@@ -27,10 +27,11 @@ with open(tf_dir + 'bert_config.json', 'r') as f:
 
 torch_state_dict = {}
 
-prefix = 'bert'
+prefix = 'roformer'
 mapping = {
 'bert/embeddings/word_embeddings':  f'{prefix}.embeddings.word_embeddings.weight',
-'bert/embeddings/position_embeddings':  f'{prefix}.embeddings.position_embeddings.weight',
+# 苏神tf ckpt中不存在该层, 舍去
+#'bert/embeddings/position_embeddings':  f'{prefix}.embeddings.position_embeddings.weight',
 'bert/embeddings/token_type_embeddings': f'{prefix}.embeddings.token_type_embeddings.weight',
 'bert/embeddings/LayerNorm/beta': f'{prefix}.embeddings.LayerNorm.bias',
 'bert/embeddings/LayerNorm/gamma': f'{prefix}.embeddings.LayerNorm.weight',

--- a/examples/convert_script/convert_simbert.py
+++ b/examples/convert_script/convert_simbert.py
@@ -27,11 +27,10 @@ with open(tf_dir + 'bert_config.json', 'r') as f:
 
 torch_state_dict = {}
 
-prefix = 'roformer'
+prefix = 'bert'
 mapping = {
 'bert/embeddings/word_embeddings':  f'{prefix}.embeddings.word_embeddings.weight',
-# 苏神tf ckpt中不存在该层, 舍去
-#'bert/embeddings/position_embeddings':  f'{prefix}.embeddings.position_embeddings.weight',
+'bert/embeddings/position_embeddings':  f'{prefix}.embeddings.position_embeddings.weight',
 'bert/embeddings/token_type_embeddings': f'{prefix}.embeddings.token_type_embeddings.weight',
 'bert/embeddings/LayerNorm/beta': f'{prefix}.embeddings.LayerNorm.bias',
 'bert/embeddings/LayerNorm/gamma': f'{prefix}.embeddings.LayerNorm.weight',


### PR DESCRIPTION
1.新增苏神的roformer-sim（simbert v2）转化为pytorch的脚本，主要区别在于位置编码层的处理；
2.集成roberta-small/tiny模型，提供苏神（非key+版本）模型的转化脚本增加base基础测试脚本；
3.修改一些笔误