### PR TITLE
fix: correct failded→failed typo in LayerMix warning (bert4torch/layers/misc.py)

### DIFF
--- a/bert4torch/layers/misc.py
+++ b/bert4torch/layers/misc.py
@@ -302,7 +302,7 @@ class MixUp(nn.Module):
                 try:
                     layer_mix = random.randint(0, len(model.encoderLayer))
                 except:
-                    warnings.warn('LayerMix random failded')
+                    warnings.warn('LayerMix random failed')
                     layer_mix = 0
             else:
                 layer_mix = self.layer_mix


### PR DESCRIPTION
Correct typo `failded` → `failed` in warnings.warn() message for LayerMix initialization failure.

**File**: bert4torch/layers/misc.py line 305
**Change**: warnings.warn('LayerMix random failded') → warnings.warn('LayerMix random failed')